### PR TITLE
Fixed bug in nlp.R to restrict by tokenNames vector explicitly

### DIFF
--- a/R/nlp.R
+++ b/R/nlp.R
@@ -416,6 +416,7 @@ parseAnnoXML = function(xml) {
     index = match(tokenNames, names(df))
     if (length(index) != ncol(df)) df = df[,index[!is.na(index)]]
     if (any(is.na(index))) df = fillDF(df, tokenNames)
+    df = df[,tokenNames]
 
     out$token = rbind(out$token, df)
 


### PR DESCRIPTION
The code provided was not completely restricting by the tokenNames vector names for some reason. It would allow more fields to be added, and when a sentence resulted in more fields in the df dataframe to be appended to the out$tokens dataframe, the code would throw an error when implementing rbind. This was especially prevalent with certain number based tokens such as "second" or 21st or footnotes like [5]. The change committed eliminates that.